### PR TITLE
Solutions

### DIFF
--- a/_episodes/03-working-with-files.md
+++ b/_episodes/03-working-with-files.md
@@ -99,10 +99,10 @@ Lists every file in `/usr/bin` that ends in the characters `.sh`.
 > what you need to solve the bonus problem.
 > 
 > > ## Solution
-> > 1. ls /usr/bin/c*
-> > 2. ls /usr/bin/*a*
-> > 3. ls /usr/bin/*o
-> > Bonus: 
+> > 1. `ls /usr/bin/c*`
+> > 2. `ls /usr/bin/*a*`
+> > 3. `ls /usr/bin/*o`  
+> > Bonus: `ls /usr/bin/*[ac]*`
 > > 
 > {: .solution}
 {: .challenge}
@@ -156,6 +156,10 @@ You will be glad you learned this when you need to re-run very complicated comma
 > ## Exercise
 > Find the line number in your history for the command that listed all the .sh
 > files in `/usr/bin`. Rerun that command.
+>
+> > ## Solution
+> > First type `history`. Then use `!` followed by the line number to rerun that command.
+> {: .solution}
 {: .challenge}
 
 
@@ -198,7 +202,7 @@ are identical to the `man` program.
 Enter the following command:
 
 ~~~
-$ less SRR098026.fastq
+$ less SRR097977.fastq
 ~~~
 {: .bash}
 
@@ -416,11 +420,26 @@ you will be asked whether you want to override your permission settings.
 
 > ## Exercise
 >
-> Do the following:
-> 1. Make sure that you have deleted your backup directory and all files it contains.
-> 1. Create a copy of each of your FASTQ files. (Note: You'll need to do this individually for each of the two FASTQ files. We haven't 
+> Do the following:  
+> 1. Make sure that you have deleted your backup directory and all files it contains.  
+> 2. Create a copy of each of your FASTQ files. (Note: You'll need to do this individually for each of the two FASTQ files. We haven't 
 > learned yet how to do this
-> with a wild-card.)
-> 1. Use a wildcard to move all of your backup files to a new backup directory. 
-> 1. Change the permissions on all of your backup files to be write-protected.
+> with a wild-card.)  
+> 3. Use a wildcard to move all of your backup files to a new backup directory.   
+> 4. Change the permissions on all of your backup files to be write-protected.  
+>
+> > ## Solution
+> >
+> > 1. `rm -r backup`  
+> > 2. `cp SRR098026.fastq SRR098026-backup.fastq` and `cp SRR097977.fastq SRR097977-backup.fastq`  
+> > 3. `mkdir backup` and `mv *-backup.fastq backup`
+> > 4. `chmod -w backup/*-backup.fastq`   
+> > It's always a good idea to check your work with `ls -l backup`. You should see something like: 
+> > 
+> > ~~~
+> > -r--r--r-- 1 dcuser dcuser 47649 Oct 20 16:59 SRR097977-backup.fastq
+> > -r--r--r-- 1 dcuser dcuser 43421 Oct 20 16:59 SRR098026-backup.fastq
+> > ~~~
+> > {: .output}
+> {: .solution}
 {: .challenge}

--- a/_episodes/04-redirection.md
+++ b/_episodes/04-redirection.md
@@ -67,6 +67,12 @@ CNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
 > 2) Search for the sequence AAGTT in both FASTQ files.
 > Have your search return all matching lines and the name (or identifier) for each sequence
 > that contains a match.
+> 
+> > ## Solution  
+> > 1) `grep -B1 GNATNACCACTTCC SRR098026.fastq`  
+> > 2) `grep -B1 AAGTT *.fastq`
+> >
+> {: .solution}
 {: .challenge}
 
 ## Redirecting output
@@ -120,10 +126,18 @@ four to get the number of sequences that match our search pattern.
 > How many sequences in SRR098026.fastq contain at least 3 consecutive Ns?
 >
 >> ## Solution
->> We can do it in one step, using the `|` pipe:
->>  ~~~
->>  $ grep NNN SRR098026.fastq | wc -l
->>  ~~~
+>> We can do it in one step, using the `|` pipe:  
+>>
+>> ~~~
+>> $ grep NNN SRR098026.fastq | wc -l
+>> ~~~
+>> {: .bash}
+>> 
+>> ~~~
+>> 250
+>> ~~~
+>> {: .output}
+>>
 > {: .solution}
 {: .challenge}
 
@@ -312,6 +326,11 @@ sequencing.
 >> ~~~
 >> {: .bash}
 >> 
+>> ~~~
+>> 35
+>> ~~~
+>> {: .output}
+>>
 > {: .solution}
 {: .challenge}
 
@@ -371,12 +390,37 @@ $ cut -f3 SraRunTable.txt | grep -v LibraryLayout_s | sort | uniq -c
 {: .output}
 
 > ## Exercise
-> a) How many different sample load dates are there? 
-> b) How many samples were loaded on each date?
+> 1) How many different sample load dates are there?   
+> 2) How many samples were loaded on each date?  
 > 
 >> ## Solution
->> 
->> 
+>>  
+>> There are two different sample load dates.  
+>>
+>> ~~~
+>> cut -f5 SraRunTable.txt | grep -v LoadDate_s | sort | uniq
+>> ~~~
+>> {: .bash}
+>>
+>> ~~~
+>> 25-Jul-12
+>> 29-May-14
+>> ~~~
+>> {: .output}
+>>
+>> Six samples were loaded on one date and 31 were loaded on the other.  
+>>
+>> ~~~
+>> cut -f5 SraRunTable.txt | grep -v LoadDate_s | sort | uniq -c
+>> ~~~
+>> {: .bash}
+>>
+>> ~~~
+>>  6 25-Jul-12
+>> 31 29-May-14
+>> ~~~
+>> {: .output}
+>>
 > {: .solution}
 {: .challenge}
 
@@ -423,4 +467,11 @@ $ grep PAIRED SraRunTable.txt > SraRunTable_only_paired_end.txt
 > ## Exercise
 > Sort samples by load date and export each of those sets to a new file (one new file per
 > unique load date). 
+> 
+> > ## Solution
+> > 
+> > `grep 25-Jul-12 SraRunTable.txt > SraRunTable_25-Jul-12.txt`  
+> > `grep 29-May-14 SraRunTable.txt > SraRunTable_29-May-14.txt`
+> >
+> {: .solution}
 {: .challenge}

--- a/_episodes/05-writing-scripts.md
+++ b/_episodes/05-writing-scripts.md
@@ -49,6 +49,14 @@ Now you've written a file. You can take a look at it with `less` or `cat`, or op
 > ## Exercise
 >
 > Open `README.txt` and add the date to the top of the file and save the file.
+>
+> > ## Solution
+> > 
+> > Use `nano README.txt` to open the file.  
+> > Add today's date and then use `Ctrl-X` to exit and `y` to save.
+> >
+> {: .solution}
+>
 {: .challenge}
 
 ## Writing scripts
@@ -86,8 +94,8 @@ It will look like nothing happened, but now if you look at `scripted_bad_reads.t
 
 > ## Exercise
 >
-> We want the script to tell us when it's done.
-> 1. Open `bad-reads-script.sh` and add the line `echo "Script finished!"` after the `grep` command and save the file.
+> We want the script to tell us when it's done.  
+> 1. Open `bad-reads-script.sh` and add the line `echo "Script finished!"` after the `grep` command and save the file.  
 > 2. Run the updated script.
 {: .challenge}
 

--- a/_episodes/06-organization.md
+++ b/_episodes/06-organization.md
@@ -61,18 +61,21 @@ You should see the output:
 {: .callout}
 
 > ## Exercise  
-> Use the `mkdir` command to make the following directories. 
-> * dc_workshop   
-> * dc_workshop/docs
-> * dc_workshop/data  
-> * dc_workshop/results 
+> Use the `mkdir` command to make the following directories:   
+> dc_workshop     
+> dc_workshop/docs  
+> dc_workshop/data    
+> dc_workshop/results   
 > 
 > > ## Solution
 > > 
+> > ~~~
 > > $ mkdir dc_workshop
 > > $ mkdir dc_workshop/docs
 > > $ mkdir dc_workshop/data
 > > $ mkdir dc_workshop/results
+> > ~~~
+> > {: .bash}
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
Add solutions for all existing exercises. Fixes https://github.com/datacarpentry/shell-genomics/issues/71 and https://github.com/datacarpentry/shell-genomics/issues/64. 

There are two empty exercise boxes in the redirection episode. I left those in as those are really good points to have exercises, but there is no content in those exercises yet and therefore no solutions.