### PR TITLE
remove old reference to AMI

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,14 +17,11 @@ There are many reasons to learn about the shell.
 > their own computers to ensure the proper setup of tools for an efficient 
 > workflow. <br>**These lessons assume no prior knowledge of the skills or tools.**
 >
-> To get started, follow the directions in the "[Setup](setup/)" tab to 
-> download data to your computer and follow any installation instructions.
->
 > #### Prerequisites
 >
 > This lesson uses data hosted on an Amazon Machine Instance (AMI). Workshop participants will be given information on how
 > to log-in to the AMI during the workshop. Learners using these materials for self-directed study will need to set up their own
-> AMI. Information on setting up an AMI and accessing the required data is provided on the [Genomics Workshop overview page](http://www.datacarpentry.org/genomics-workshop/) under "Teaching Platform".
+> AMI. Information on setting up an AMI and accessing the required data is provided on the [Genomics Workshop setup page](http://www.datacarpentry.org/genomics-workshop/setup/).
 {: .prereq}
 
 > ## For Instructors


### PR DESCRIPTION
The getting started box had an outdated reference to where to find information about connecting to the AMI.
