### PR TITLE
avoiding pipe in exercise

### DIFF
--- a/_episodes/04-redirection.md
+++ b/_episodes/04-redirection.md
@@ -174,10 +174,11 @@ four to get the number of sequences that match our search pattern.
 > How many sequences in `SRR098026.fastq` contain at least 3 consecutive Ns?
 >
 >> ## Solution
->> We can do it in one step, using the `|` pipe:  
+>>  
 >>
 >> ~~~
->> $ grep NNN SRR098026.fastq | wc -l
+>> $ grep NNN SRR098026.fastq > bad_reads.txt
+>> $ wc -l bad_reads.txt
 >> ~~~
 >> {: .bash}
 >> 


### PR DESCRIPTION
The pipe is only introduced later in this episode, and the next step after this exercise makes more sense without the pipe solution
