### PR TITLE
Change base url for stylesheets so that subpage like Reference render well

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -9,10 +9,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- meta "search-domain" used for google site search function google_search() -->
     <meta name="search-domain" value="{{ site.github.url }}">
-    <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/bootstrap.css" />
-    <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/bootstrap-theme.css" />
-    <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/lesson.css" />
-    <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/syntax.css" />
+    <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/bootstrap.css" />
+    <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/bootstrap-theme.css" />
+    <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/lesson.css" />
+    <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/syntax.css" />
 
     {% include favicons.html %}
 


### PR DESCRIPTION
Currently, the reference page for the data carpentry lessons does not load the stylesheets: https://datacarpentry.org/shell-genomics/reference/

If the variable `page.root` is changed for `site.baseurl` the stylesheets can be found again. The stylesheets are note relative to the actual page, but to the site root.

Working site can be seen at https://mdehollander.github.io/shell-genomics/reference/ 