### PR TITLE
Exercise with `echo` to show how it differs from `ls`

### DIFF
--- a/_episodes/03-working-with-files.md
+++ b/_episodes/03-working-with-files.md
@@ -9,7 +9,7 @@ questions:
 - "How can I repeat recently used commands?"
 objectives:
 - View, search within, copy, move, and rename files. Create new directories.
-- Use wild cards (`*`) to perform operations on multiple files.
+- Use wildcards (`*`) to perform operations on multiple files.
 - Make a file read only
 - Use the `history` command to view and repeat recently used commands.
 keypoints:
@@ -27,7 +27,7 @@ Now that we know how to navigate around our directory structure, lets
 start working with our sequencing files. We did a sequencing experiment and 
 have two results files, which are stored in our `untrimmed_fastq` directory. 
 
-### Wild cards
+### Wildcards
 
 Navigate to your `untrimmed_fastq` directory.
 
@@ -528,7 +528,7 @@ you will be asked whether you want to override your permission settings.
 > 1. Make sure that you have deleted your backup directory and all files it contains.  
 > 2. Create a copy of each of your FASTQ files. (Note: You'll need to do this individually for each of the two FASTQ files. We haven't 
 > learned yet how to do this
-> with a wild-card.)  
+> with a wildcard.)  
 > 3. Use a wildcard to move all of your backup files to a new backup directory.   
 > 4. Change the permissions on all of your backup files to be write-protected.  
 >

--- a/_episodes/03-working-with-files.md
+++ b/_episodes/03-working-with-files.md
@@ -66,21 +66,6 @@ SRR097977.fastq
 
 lists only the file that ends with `977.fastq`.
 
-We can use the command `echo` to see how the wildcard character is intepreted by the
-shell.
-
-~~~
-$ echo *.fastq
-~~~
-{: .bash}
-
-~~~
-SRR097977.fastq SRR098026.fastq
-~~~
-{: .output}
-
-The `*` is expanded to include any file that ends with `.fastq`.
-
 This command:
 
 ~~~
@@ -131,6 +116,49 @@ Lists every file in `/usr/bin` that ends in the characters `.sh`.
 > > 2. `ls /usr/bin/*a*`
 > > 3. `ls /usr/bin/*o`  
 > > Bonus: `ls /usr/bin/*[ac]*`
+> > 
+> {: .solution}
+{: .challenge}
+
+> ## Exercise
+> We can use the command `echo` to see how the wildcard character is interpreted by the shell.
+> 
+> ~~~
+> $ echo *.fastq
+> ~~~
+> {: .bash}
+> 
+> ~~~
+> SRR097977.fastq SRR098026.fastq
+> ~~~
+> {: .output}
+> 
+> The `*` is expanded to include any file that ends with `.fastq`. We can see that the output of
+> `echo *.fastq` is the same as of `ls *.fastq`.
+> 
+> What would the output look like if the wildcard could *not* be matched? Compare the outputs of
+> `echo *.missing` and `ls *.missing`.
+> 
+> > ## Solution
+> > ~~~
+> > $ echo *.missing
+> > ~~~
+> > {: .bash}
+> > 
+> > ~~~
+> > *.missing
+> > ~~~
+> > {: .output}
+> > 
+> > ~~~
+> > $ ls *.missing
+> > ~~~
+> > {: .bash}
+> > 
+> > ~~~
+> > ls: cannot access '*.missing': No such file or directory
+> > ~~~
+> > {: .output}
 > > 
 > {: .solution}
 {: .challenge}

--- a/_episodes/05-writing-scripts.md
+++ b/_episodes/05-writing-scripts.md
@@ -109,7 +109,7 @@ A really powerful thing about the command line is that you can write scripts. Sc
 
 One thing we will commonly want to do with sequencing results is pull out bad reads and write them to a file to see if we can figure out what's going on with them. We're going to look for reads with long sequences of N's like we did before, but now we're going to write a script, so we can run it each time we get new sequences, rather than type the code in by hand each time.
 
-Bad reads have a lot of N's, so we're going to look for  `NNNNNNNNNN` with `grep`. We want the whole FASTQ record, so we're also going to get the one line above the sequence and the two lines below. We also want to look in all the files that end with `.fastq`, so we're going to use the `*` wild card.
+Bad reads have a lot of N's, so we're going to look for  `NNNNNNNNNN` with `grep`. We want the whole FASTQ record, so we're also going to get the one line above the sequence and the two lines below. We also want to look in all the files that end with `.fastq`, so we're going to use the `*` wildcard.
 
 ~~~
 grep -B1 -A2 NNNNNNNNNN *.fastq > scripted_bad_reads.txt


### PR DESCRIPTION
Move the introduction of `echo` to an exercise. The exercise shows the difference between `echo` and `ls` by attempting to expand a wildcard which could not be expanded. This addresses #143.