### PR TITLE
Update setup.md

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -4,9 +4,6 @@ title: Setup
 ---
 
 This workshop is designed to be run on pre-imaged Amazon Web Services 
-(AWS) instances. All the software and data used in the workshop are 
-hosted on an Amazon Machine Image (AMI). For information about how to
+(AWS) instances. For information about how to
 use the workshop materials, see the 
 [setup instructions](http://www.datacarpentry.org/genomics-workshop/setup.html) on the main workshop page.
-
-


### PR DESCRIPTION
Remove "all data and software are available on AMI" - as the workshop also requires learners to have a spreadsheet program which is not included on the AMI. See also https://github.com/datacarpentry/genomics-workshop/pull/63