### PR TITLE
Include space after the flag '-n' in line 362

### DIFF
--- a/_episodes/03-working-with-files.md
+++ b/_episodes/03-working-with-files.md
@@ -359,7 +359,7 @@ We can view the first complete read in one of the files our dataset by using `he
 the first four lines.
 
 ~~~
-$ head -n4 SRR098026.fastq
+$ head -n 4 SRR098026.fastq
 ~~~
 {: .bash}
 


### PR DESCRIPTION
Great document! Thanks for coming up with this fantastic resource! 

In line 362, I miss a space after the flag '-n'. Even though without using space the commands works as well, in the previous use of that flag there was always space so I guess to keep the consistency within the document I would add this space.

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
