### PR TITLE
Extra character in the solution from the exercise  'Print out the con…

### DIFF
--- a/_episodes/03-working-with-files.md
+++ b/_episodes/03-working-with-files.md
@@ -215,7 +215,7 @@ This will print out all of the contents of the `SRR098026.fastq` to the screen.
 > the `~/shell_data/untrimmed_fastq` directory.
 > 
 > > ## Solution
-> > 1. The last line of the file is `TC:CCC::CCCCCCCC<8?6A:C28C<608'&&&,'$`.
+> > 1. The last line of the file is `C:CCC::CCCCCCCC<8?6A:C28C<608'&&&,'$`.
 > > 2. `cat ~/shell_data/untrimmed_fastq/*`
 > {: .solution}
 {: .challenge}


### PR DESCRIPTION
…tents of the `~/shell_data/untrimmed_fastq/SRR097977.fastq'

Fantastic resource! Thanks a lot for coming up with this! 

I found an extra initial nucleotide 'T' in the solution given in the document.

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
