### PR TITLE
Modify the explanation of 'N' in DNA sequences

### DIFF
--- a/_episodes/04-redirection.md
+++ b/_episodes/04-redirection.md
@@ -35,8 +35,8 @@ Let's give it a try!
 > The four nucleotides that appear in DNA are abbreviated `A`, `C`, `T` and `G`. 
 > Unknown nucleotides are represented with the letter `N`. An `N` appearing
 > in a sequencing file represents a position where the sequencing machine was not able to 
-> confidently determine the nucleotide in that position. You can think of an `N` as a `NULL` value
-> within a DNA sequence. 
+> confidently determine the nucleotide in that position. You can think of an `N` as being aNy 
+> nucleotide at that position in the DNA sequence. 
 > 
 {: .callout}
 


### PR DESCRIPTION
The original sentence was: _You can think of an `N` as a `NULL` value within a DNA sequence._
Given the target audience, this statement is confusing. It makes sense from a CS point of view regarding the information content, but if we assume that learners come from biology, they probably aren't familiar with the concept of `NULL`. And if they would be, they might interpret this statement as _there is no nucleotide in this position_ (which doesn't make biological sense).