### PR TITLE
Change order of paragraphs in Writing Scripts

### DIFF
--- a/_episodes/05-writing-scripts.md
+++ b/_episodes/05-writing-scripts.md
@@ -131,17 +131,17 @@ A really powerful thing about the command line is that you can write scripts. Sc
 
 One thing we will commonly want to do with sequencing results is pull out bad reads and write them to a file to see if we can figure out what's going on with them. We're going to look for reads with long sequences of N's like we did before, but now we're going to write a script, so we can run it each time we get new sequences, rather than type the code in by hand each time.
 
-Bad reads have a lot of N's, so we're going to look for  `NNNNNNNNNN` with `grep`. We want the whole FASTQ record, so we're also going to get the one line above the sequence and the two lines below. We also want to look in all the files that end with `.fastq`, so we're going to use the `*` wildcard.
-
-~~~
-grep -B1 -A2 NNNNNNNNNN *.fastq > scripted_bad_reads.txt
-~~~
-{: .bash}
-
 We're going to create a new file to put this command in. We'll call it `bad-reads-script.sh`. The `sh` isn't required, but using that extension tells us that it's a shell script.
 
 ~~~
 $ nano bad-reads-script.sh
+~~~
+{: .bash}
+
+Bad reads have a lot of N's, so we're going to look for  `NNNNNNNNNN` with `grep`. We want the whole FASTQ record, so we're also going to get the one line above the sequence and the two lines below. We also want to look in all the files that end with `.fastq`, so we're going to use the `*` wildcard.
+
+~~~
+grep -B1 -A2 NNNNNNNNNN *.fastq > scripted_bad_reads.txt
 ~~~
 {: .bash}
 


### PR DESCRIPTION
In the section 'Writing Scripts': change the order of the paragraphs so that first the script file is created and then the grep command is added to the script. When it's the other way around there is a chance the learner will see the grep command then run it on the command line before creating the script. This will create the file and then running the script will have no discernible output.