### PR TITLE
Fix typo

### DIFF
--- a/_episodes/06-organization.md
+++ b/_episodes/06-organization.md
@@ -263,7 +263,7 @@ $ ls
 {: .bash}
 
 ~~~
-shell_data	dc_workshop dc_workshop_log_2017_10_27.txt
+shell_data	dc_workshop dc_workshop_log_2017_10_27.sh
 ~~~
 {: .output}
 


### PR DESCRIPTION
Minor typo: the file 'dc_workshop_log_2017_10_27' has a .sh-extension, but was listed as .txt.