### PR TITLE
Update commands starting with 'pw'

### DIFF
--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -348,7 +348,7 @@ $ pw<tab><tab>
 {: .bash}
 
 ~~~
-pwd         pwd_mkdb    pwhich      pwhich5.16  pwhich5.18  pwpolicy
+pwck      pwconv    pwd       pwdx      pwunconv
 ~~~
 {: .output}
 


### PR DESCRIPTION
The command `pq<tab><tab>`  gives a different list of commands than the example. I guess this is a newer version of the VM, so learners will also see different commands. (Tested 22 November 2019.)