### PR TITLE
relating to issue #268

### DIFF
--- a/_episodes/04-redirection.md
+++ b/_episodes/04-redirection.md
@@ -449,7 +449,9 @@ foo is
 
 The interpreter is trying to expand a variable named `fooEFG`, which (probably)
 doesn't exist. We can avoid this problem by enclosing the variable name in 
-braces (`{` and `}`, sometimes called "squiggle braces").
+braces (`{` and `}`, sometimes called "squiggle braces"). `bash` treats the `#`
+character as a comment character. Any text on a line after a `#` is ignored by
+bash when evaluating the text as code.
 
 ~~~
 $ foo=abc

--- a/_episodes/06-organization.md
+++ b/_episodes/06-organization.md
@@ -212,15 +212,14 @@ From the `nano` screen, you can use your cursor to navigate, type, and delete an
 > 
 {: .callout}
 
-Add a date line and comment to the line where you have created the directory, for example:   
+Add a date line and comment to the line where you have created the directory. Recall that any
+text on a line after a `#` is ignored by bash when evaluating the text as code. For example:   
 
 ~~~
 # 2017_10_27   
 # Created sample directories for the Data Carpentry workshop  
 ~~~
 {: .bash}
-
-`bash` treats the `#` character as a comment character. Any text on a line after a `#` is ignored by bash when evaluating the text as code.
 
 Next, remove any lines of the history that are not relevant by navigating to those lines and using your 
 delete key. Save your file and close `nano`.


### PR DESCRIPTION
Continuing the discussion from #268, here is a potential fix to clarify `#`. How does this look, @datacarpentry/shell-genomics-maintainers?