### PR TITLE
Suggested fixes for issue #289: Error in wc -l output of "Redirecting output"

### DIFF
--- a/_episodes/04-redirection.md
+++ b/_episodes/04-redirection.md
@@ -185,7 +185,12 @@ happened. But type `ls`. You should see a new file called `bad_reads.txt`.
 
 We can check the number of lines in our new file using a command called `wc`. 
 `wc` stands for **word count**. This command counts the number of words, lines, and characters
-in a file. 
+in a file. The FASTQ file may change over time, so given the potential for updates, 
+make sure your file matches your instructor's output. 
+
+As of Sept. 2020, wc gives the following output:  
+
+
 
 ~~~
 $ wc bad_reads.txt
@@ -193,7 +198,7 @@ $ wc bad_reads.txt
 {: .bash}
 
 ~~~
-  537  1073 23217 bad_reads.txt
+  802    1338   24012 bad_reads.txt
 ~~~
 {: .output}
 
@@ -206,7 +211,7 @@ $ wc -l bad_reads.txt
 {: .bash}
 
 ~~~
-537 bad_reads.txt
+802 bad_reads.txt
 ~~~
 {: .output}
 
@@ -244,7 +249,7 @@ $ wc -l bad_reads.txt
 {: .bash}
 
 ~~~
-537 bad_reads.txt
+802 bad_reads.txt
 ~~~
 {: .output}
 
@@ -273,7 +278,7 @@ $ wc -l bad_reads.txt
 {: .bash}
 
 ~~~
-537 bad_reads.txt
+802 bad_reads.txt
 ~~~
 {: .output}
 
@@ -284,7 +289,7 @@ $ wc -l bad_reads.txt
 {: .bash}
 
 ~~~
-537 bad_reads.txt
+802 bad_reads.txt
 ~~~
 {: .output}
 
@@ -299,7 +304,7 @@ $ wc -l bad_reads.txt
 {: .bash}
 
 ~~~
-537 bad_reads.txt
+802 bad_reads.txt
 ~~~
 {: .output}
 
@@ -362,7 +367,7 @@ $ grep -B1 -A2 NNNNNNNNNN SRR098026.fastq | wc -l
 {: .bash}
 
 Because we asked `grep` for all four lines of each FASTQ record, we need to divide the output by
-four to get the number of sequences that match our search pattern. Since 537 / 4 = 134.25 and we
+four to get the number of sequences that match our search pattern. Since 802 / 4 = 200.5 and we
 are expecting an integer number of records, there is something added or missing in `bad_reads.txt`. 
 If we explore `bad_reads.txt` using `less`, we might be able to notice what is causing the uneven 
 number of lines. Luckily, this issue happens by the end of the file so we can also spot it with `tail`.

--- a/_episodes/04-redirection.md
+++ b/_episodes/04-redirection.md
@@ -373,6 +373,7 @@ If we explore `bad_reads.txt` using `less`, we might be able to notice what is c
 number of lines. Luckily, this issue happens by the end of the file so we can also spot it with `tail`.
 
 ~~~
+$ grep -B1 -A2 NNNNNNNNNN SRR098026.fastq > bad_reads.txt
 $ tail bad_reads.txt
 ~~~
 {: .bash}
@@ -383,6 +384,7 @@ ANNNNNNNNNTTCAGCGACTNNNNNNNNNNGTNGN
 +SRR098026.133 HWUSI-EAS1599_1:2:1:0:1978 length=35
 #!!!!!!!!!##########!!!!!!!!!!##!#!
 --
+--
 @SRR098026.177 HWUSI-EAS1599_1:2:1:1:2025 length=35
 CNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
 +SRR098026.177 HWUSI-EAS1599_1:2:1:1:2025 length=35
@@ -390,14 +392,29 @@ CNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
 ~~~
 {: .output}
 
-The fifth line in the output displays "--" which is the default action for `grep` to separate groups of 
+The fifth and six lines in the output display "--" which is the default action for `grep` to separate groups of 
 lines matching the pattern, and indicate groups of lines which did not match the pattern so are not displayed. 
 To fix this issue, we can redirect the output of grep to a second instance of `grep` as follows.
 
 ~~~
 $ grep -B1 -A2 NNNNNNNNNN SRR098026.fastq | grep -v '^--' > bad_reads.fastq
+tail bad_reads.fastq
 ~~~
 {: .bash}
+
+~~~
++SRR098026.132 HWUSI-EAS1599_1:2:1:0:320 length=35
+#!!!!!!!!!##########!!!!!!!!!!##!#!
+@SRR098026.133 HWUSI-EAS1599_1:2:1:0:1978 length=35
+ANNNNNNNNNTTCAGCGACTNNNNNNNNNNGTNGN
++SRR098026.133 HWUSI-EAS1599_1:2:1:0:1978 length=35
+#!!!!!!!!!##########!!!!!!!!!!##!#!
+@SRR098026.177 HWUSI-EAS1599_1:2:1:1:2025 length=35
+CNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
++SRR098026.177 HWUSI-EAS1599_1:2:1:1:2025 length=35
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+~~~
+{: .output}
 
 The `-v` option in the second `grep` search stands for `--invert-match` meaning `grep` will now only display the 
 lines which do not match the searched pattern, in this case `'^--'`. The caret (`^`) is an **anchoring** 


### PR DESCRIPTION
Suggested modifications to fix issue #289. Because several downstream parts of the lesson depend on the number of lines in the "bad_reads.txt" file, I had to modify several places in the lesson to reflect changes in the data set.

In summary: Added note saying that FASTQ files downloaded from FigShare may be updated from time to time, updated results of wc throughout to reflect the output I am currently getting from these files. Had to adjust numbers in paragraph starting with "because we asked grep for all 4 lines..." to reflect new content of SRR098026.fastq. Added modified command in line 376 to make sure command produced expected output. Made sure following block of output (lines 382-392) reflected exactly what I got out of these commands on the current version of the FASTQ. Added an output block in lines 406-415 to help students validate their output.

@datacarpentry/shell-genomics-maintainers please take a look and make sure output from tail etc. matches what you are also getting from this version of the file before merging this pull request. Thank you!
