### PR TITLE
count reads in fastq exercise (checkout)

### DIFF
--- a/_episodes/04-redirection.md
+++ b/_episodes/04-redirection.md
@@ -217,6 +217,28 @@ $ wc -l bad_reads.txt
 
 > ## Exercise
 >
+> How many sequences are there in `SRR098026.fastq`? Remember that every sequence is formed by four lines.
+>
+>> ## Solution
+>>
+>>
+>> ~~~
+>> $ wc -l SRR098026.fastq
+>> ~~~
+>> {: .bash}
+>>
+>> ~~~
+>> 996
+>> ~~~
+>> {: .output}
+>>
+> {: .solution}
+> Now you can divide this number by four to get the number of sequences in your fastq file
+{: .challenge}
+
+
+> ## Exercise
+>
 > How many sequences in `SRR098026.fastq` contain at least 3 consecutive Ns?
 >
 >> ## Solution


### PR DESCRIPTION
Please delete the text below before submitting your contribution. 

---

Hello, I added a small exercise to count the number of lines in a fastq file, which then can be divided by four to obtain the number of reads. I think it can be useful to get an idea of the size of your data.
---
