### PR TITLE
Minor changes and typos

### DIFF
--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -49,12 +49,16 @@ In this lesson you will learn how to use the command line interface to move arou
 ## How to access the shell
 
 On a Mac or Linux machine, you can access a shell through a program called "Terminal", which is already available
-on your computer. The Terminal is a window into which we will type commands. If you're using Windows, you'll need to download a separate program to access the shell.
+on your computer. The Terminal is a window into which we will type commands. If you're using Windows,
+you'll need to download a separate program to access the shell.
 
-To save time, we are going to be working on a remote server where all the necessary data and software available. When we say a 'remote sever', we are talking about a computer that is not the one you are working on right now. You will access the Carpentries remote server where everything is prepared for the lesson.
+To save time, we are going to be working on a remote server where all the necessary data and software available.
+When we say a 'remote server', we are talking about a computer that is not the one you are working on right now.
+You will access the Carpentries remote server where everything is prepared for the lesson.
 We will learn the basics of the shell by manipulating some data files. Some of these files are very large
 , and would take time to download to your computer.
-We will also be using several bioinformatic packages in later lessons and installing all of the software would take up time even more time. A 'ready-to-go' sever let's us focus on learning. 
+We will also be using several bioinformatic packages in later lessons and installing all of the software
+would take up time even more time. A 'ready-to-go' server lets us focus on learning. 
 
 ## How to access the remote server
 

--- a/_episodes/04-redirection.md
+++ b/_episodes/04-redirection.md
@@ -495,7 +495,7 @@ foo is
 
 The interpreter is trying to expand a variable named `fooEFG`, which (probably)
 doesn't exist. We can avoid this problem by enclosing the variable name in 
-braces (`{` and `}`, sometimes called "squiggle braces"). `bash` treats the `#`
+braces (`{` and `}`, also called "curly brackets"). `bash` treats the `#`
 character as a comment character. Any text on a line after a `#` is ignored by
 bash when evaluating the text as code.
 

--- a/_episodes/04-redirection.md
+++ b/_episodes/04-redirection.md
@@ -362,10 +362,10 @@ the file to see how many reads matched our criteria. There's a way to do this, h
 doesn't require us to create these intermediate files - the pipe command (`|`).
 
 This is probably not a key on
-your keyboard you use very much, so let's all take a minute to find that key. For the standard QWERTY keyboard
-layout, the `|` character can be found using the key combination
-
-- <kbd>Shift</kbd>+<kbd>\</kbd>
+your keyboard you use very much, so let's all take a minute to find that key.
+In the UK and US keyboard layouts, and several others,
+the `|` character can be found using the key combination <kbd>Shift</kbd>+<kbd>\</kbd>.
+This may be different for other language-specific layouts.
 
 What `|` does is take the output that is scrolling by on the terminal and uses that output as input to another command. 
 When our output was scrolling by, we might have wished we could slow it down and

--- a/_episodes/04-redirection.md
+++ b/_episodes/04-redirection.md
@@ -232,8 +232,9 @@ $ wc -l bad_reads.txt
 >> ~~~
 >> {: .output}
 >>
+>> Now you can divide this number by four to get the number of sequences in your fastq file.
+>>
 > {: .solution}
-> Now you can divide this number by four to get the number of sequences in your fastq file
 {: .challenge}
 
 

--- a/index.md
+++ b/index.md
@@ -5,15 +5,15 @@ layout: lesson
 {% include gh_variables.html %}
 
 
-Command line interface (CLI) and graphic user interface (GUI) are different ways of interacting with a computer's operating system. They have different pros and cons. Most people are familiar with the GUI as it is the default interface for most software, particularly on Windows and Mac OS. When using the GUI, you see visual representations of files, folders, applications etc. 
-When using the CLI, you work largely with text representations of files, folders, input and output etc.
-The shell is a program that presents a command line interface that allows you to control your computer by typing instructions with a keyboard.
+Command line interface (CLI) and graphic user interface (GUI) are different ways of interacting with a computer's operating system. They have different pros and cons. Most people are familiar with the GUI as it is the default interface for most software, particularly on Windows and Mac OS. When using the GUI, you see and interact with visual representations of files, folders, applications, and most other functions of your computer.
+When using the CLI, you work largely with text representations of software, files, folders, input and output.
+The *shell* is a program that allows you to control your computer by typing instructions on the CLI with a keyboard.
 
 There are several reasons to learn how to use the CLI:
 
-- For most bioinformatics tools, there are no graphical interfaces. If you want to work in metagenomics or genomics you're going to need to use the CLI/ shell.
-- The shell gives you power. The command line allows you to work more efficiently. Tasks that are repetative (e.g. renaming hundreds of files) can be automated. Tasks that are tedius (e.g. testing a range of input parameters) can be simplified.
-- To use remote computers or cloud computing, you need to use the shell.
+- For most bioinformatics tools, there are no graphical interfaces. If you want to work in metagenomics or genomics, you're going to need to use the CLI/ shell.
+- The shell gives you power. The command line allows you to work more efficiently. Tasks that are repetitive (e.g. renaming hundreds of files) can be automated. Tasks that are tedious (e.g. testing a range of input parameters) can be simplified.
+- To use remote computers or cloud computing, you often need to use the shell.
 
 > ## Getting Started
 >


### PR DESCRIPTION
A few minor changes:

- In the index's introductory explanation there were at least a couple of typos. Fixes #326.
- The same introduction had some unclear 'etc.' and less polished language that I edited.
- Braces are not usually called "squiggle braces". I Googled this expression and it's essentially only found in that Carpentries lesson. I edited to "curly brackets", which is the common name of braces in British English.
- The wording "standard QWERTY keyboard" is incorrect and also not inclusive. There is no standard QWERTY. I edited to clarify, although it's impossible to give a comprehensive instruction on where the `|` key is on all keyboard layouts.
- I edited an exercise adding a line to the solution rather than as a comment after the exercise.
- Typos in episode 1, fixes #329 