### PR TITLE
Update lesson 5 to use scp as default

### DIFF
--- a/_episodes/05-writing-scripts.md
+++ b/_episodes/05-writing-scripts.md
@@ -326,11 +326,11 @@ using a transfer program, it needs to be installed on your local machine, not yo
 
 ## Transferring Data Between your Local Machine and the Cloud
 
-These directions are platform specific, so please follow the instructions for your system:
-
-**Please select the platform you wish to use for the exercises: <select id="id_platform" name="platformlist" onchange="change_content_by_platform('id_platform');return false;"><option value="unix" id="id_unix" selected> UNIX </option><option value="win" id="id_win" selected> Windows </option></select>**
-
-
+If you're using Windows with PuTTY instead of Git Bash, please select the alternative option here:
+<select id="id_platform" name="platformlist" onchange="change_content_by_platform('id_platform');return false;">
+    <option value="unix" id="id_unix" selected> Linux, Mac OS, Git Bash </option>
+    <option value="win" id="id_win"> PuTTY </option>
+</select>
 
 <div id="div_unix" style="display:block" markdown="1">
 
@@ -396,8 +396,8 @@ Remember that in both instances, the command is run from your local machine, we'
 
 ### Uploading Data to your Virtual Machine with PSCP
 
-If you're using a PC, we recommend you use the *PSCP* program. This program is from the same suite of
-tools as the PuTTY program we have been using to connect.
+If you're using a Windows PC without Git Bash, we recommend you use the *PSCP* program.
+This program is from the same suite of tools as the PuTTY program we have been using to connect.
 
 1. If you haven't done so, download pscp from [http://the.earth.li/~sgtatham/putty/latest/x86/pscp.exe](http://the.earth.li/~sgtatham/putty/latest/x86/pscp.exe)
 2. Make sure the *PSCP* program is somewhere you know on your computer. In this case,


### PR DESCRIPTION
Fixes #312.

The lesson currently shows the PuTTY option by default due to a bug (`selected` keyword used twice).

Additionally, the recommended client for the lesson (as per the setup page) is git bash. Yesterday, I taught this lesson and verified that `scp` is indeed installed in git bash, so we can teach that to everyone cross platform. I kept the PuTTY option because that's also suggested as an alternative in the setup for those that don't want to install git bash, but that's not the recommended option.