### PR TITLE
update zenodo json for lesson release

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,120 +2,114 @@
   "contributors": [
     {
       "type": "Editor",
-      "name": "Shichen Wang"
+      "name": "Saba Ferdous"
     },
     {
       "type": "Editor",
-      "name": "Anita Schürch",
-      "orcid": "0000-0003-1894-7545"
+      "name": "Stacey Borrego"
     },
     {
       "type": "Editor",
-      "name": "Bastian Greshake Tzovaras",
-      "orcid": "0000-0002-9925-9623"
+      "name": "Akshay Paropkari",
+      "orcid": "0000-0003-2284-7061"
     }
   ],
   "creators": [
     {
-      "name": "Erin Alison Becker",
-      "orcid": "0000-0002-6832-0233"
-    },
-    {
-      "name": "Anita Schürch",
+      "name": "A.C. Schürch",
       "orcid": "0000-0003-1894-7545"
     },
     {
-      "name": "Tracy Teal",
-      "orcid": "0000-0002-9180-9598"
+      "name": "Akshay Paropkari",
+      "orcid": "0000-0003-2284-7061"
     },
     {
-      "name": "Sheldon John McKay",
-      "orcid": "0000-0002-4011-3160"
+      "name": "Sally Chang"
     },
     {
-      "name": "Jessica Elizabeth Mizzi",
-      "orcid": "0000-0002-6604-4618"
+      "name": "Martino Sorbaro Sindaci",
+      "orcid": "0000-0002-0182-7443"
     },
     {
-      "name": "François Michonneau",
-      "orcid": "0000-0002-9092-966X"
+      "name": "Bianca Peterson"
     },
     {
-      "name": "Amy E. Hodge",
-      "orcid": "0000-0002-5902-3077"
+      "name": "Alicia Hadingham",
+      "orcid": "0000-0002-3258-3066"
     },
     {
-      "name": "Shannon EK Joslin",
-      "orcid": "0000-0001-5470-1193"
+      "name": "Raúl A. Ortiz-Merino",
+      "orcid": "0000-0003-4186-8941"
     },
     {
-      "name": "Taylor Reiter",
-      "orcid": "0000-0002-7388-421X"
+      "name": "Sam Nooij",
+      "orcid": "0000-0001-5892-5637"
     },
     {
-      "name": "Karen Cranston",
-      "orcid": "0000-0002-4798-9499"
-    },
-    {
-      "name": "Kari L Jordan",
-      "orcid": "0000-0003-4121-2432"
-    },
-    {
-      "name": "Tristan De Buysscher"
-    },
-    {
-      "name": "Niclas Jareborg",
-      "orcid": "0000-0002-4520-044X"
-    },
-    {
-      "name": "Tobi"
-    },
-    {
-      "name": "Amanda Charbonneau",
-      "orcid": "0000-0001-7376-7702"
-    },
-    {
-      "name": "Bastian Greshake Tzovaras",
-      "orcid": "0000-0002-9925-9623"
-    },
-    {
-      "name": "Bérénice Batut",
-      "orcid": "0000-0001-9852-1987"
-    },
-    {
-      "name": "Colin Davenport"
-    },
-    {
-      "name": "Diya Das",
-      "orcid": "0000-0001-9646-8983"
-    },
-    {
-      "name": "Giulio Valentino Dalla Riva"
-    },
-    {
-      "name": "Omar Julio Sosa",
-      "orcid": "0000-0001-5516-5724"
-    },
-    {
-      "name": "Mattias de Hollander"
-    },
-    {
-      "name": "Mike Lee"
-    },
-    {
-      "name": "Rayna Michelle Harris",
-      "orcid": "0000-0002-7943-5650"
-    },
-    {
-      "name": "Ross Cunning",
-      "orcid": "0000-0001-7241-1181"
-    },
-    {
-      "name": "Sarah Stevens",
+      "name": "Sarah LR Stevens",
       "orcid": "0000-0002-7040-548X"
     },
     {
-      "name": "Siva Chudalayandi"
+      "name": "Aleksander Jankowski"
+    },
+    {
+      "name": "Bruno A. S. de Medeiros",
+      "orcid": "0000-0003-1663-668X"
+    },
+    {
+      "name": "Clara"
+    },
+    {
+      "name": "Daniel Kerchner",
+      "orcid": "0000-0002-5921-2193"
+    },
+    {
+      "name": "Erin Roberts"
+    },
+    {
+      "name": "Felicity Anderson",
+      "orcid": "0000-0001-8778-6779"
+    },
+    {
+      "name": "Jean-Yves R Sgro",
+      "orcid": "0000-0002-2640-4949"
+    },
+    {
+      "name": "JesseKerkvliet"
+    },
+    {
+      "name": "Julian Paganini"
+    },
+    {
+      "name": "Marco Crotti"
+    },
+    {
+      "name": "Miles"
+    },
+    {
+      "name": "Mollie Peters"
+    },
+    {
+      "name": "Nadine Bestard"
+    },
+    {
+      "name": "Preethy Nair"
+    },
+    {
+      "name": "Ryan Daniels",
+      "orcid": "0000-0003-4985-3541"
+    },
+    {
+      "name": "beacurious"
+    },
+    {
+      "name": "dwwaite"
+    },
+    {
+      "name": "Chandra Sarkar"
+    },
+    {
+      "name": "Marcel van den Broek"
     }
   ],
   "license": {


### PR DESCRIPTION
updating the `.zenodo.json` with metadata about contributors since last release, in preparation for the infrastructure transition.