### PR TITLE
remove legacy jekyll template inclusion

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,8 +2,6 @@
 site: sandpaper::sandpaper_site
 ---
 
-{% include gh\_variables.html %}
-
 Command line interface (CLI) and graphic user interface (GUI) are different ways of interacting with a computer's operating system. They have different pros and cons. Most people are familiar with the GUI as it is the default interface for most software, particularly on Windows and Mac OS. When using the GUI, you see and interact with visual representations of files, folders, applications, and most other functions of your computer.
 When using the CLI, you work largely with text representations of software, files, folders, input and output.
 The *shell* is a program that allows you to control your computer by typing instructions on the CLI with a keyboard.


### PR DESCRIPTION
Hi!
This fixes #340.

Removing the line improves readability and does not seem to break anything else in the lesson, after using the following command with the [Carpentries Workbench](https://carpentries.github.io/sandpaper-docs):

```r
sandpaper::validate_lesson()
sandpaper::build_lesson()
```

Hope that helps and let me know if I should run additional tests to be sure not to break anything.
BEst, 