### PR TITLE
fixes broken link to main workshop setup page

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -5,6 +5,6 @@ title: Setup
 This workshop is designed to be run on pre-imaged Amazon Web Services
 (AWS) instances. For information about how to
 use the workshop materials, see the
-[setup instructions](https://www.datacarpentry.org/genomics-workshop/setup.html) on the main workshop page.
+[setup instructions](https://datacarpentry.org/genomics-workshop/index.html#setup) on the main workshop page.
 
 


### PR DESCRIPTION
Found this broken link.  It is right in the index but was broken on this setup page and I got a 404.