### PR TITLE
feat: Upgraded `rm -r` description to a callout

### DIFF
--- a/episodes/03-working-with-files.md
+++ b/episodes/03-working-with-files.md
@@ -577,8 +577,20 @@ $ cd ..
 $ rm -r backup
 ```
 
-This will delete not only the directory, but all files within the directory. If you have write-protected files in the directory,
-you will be asked whether you want to override your permission settings.
+:::::::::::::::::::::::::::::::::::::::::  callout
+
+## Risks of `rm`
+
+`rm -r` will delete not only the directory, but all files within the directory.
+If you have write-protected files in the directory, you will be asked whether you want to override your permission settings.
+
+**Important: This cannot be undone.**
+
+`rm -i` will prompt you to confirm that you want to delete every file regardless of permission settings.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
+
 
 :::::::::::::::::::::::::::::::::::::::  challenge
 


### PR DESCRIPTION
Closes #153 

- description of `rm -r` upgraded to a callout block to draw attention to the risks
- added bolded line "Important: this cannot be undone."
- added suggested use of `rm -i` to always prompt before deletion

Discussed on call with maintainers 30 May 2025.
