### PR TITLE
Update 04-redirection.md

### DIFF
--- a/episodes/04-redirection.md
+++ b/episodes/04-redirection.md
@@ -208,14 +208,14 @@ We can check the number of lines in our new file using a command called `wc`.
 in a file. The FASTQ file may change over time, so given the potential for updates,
 make sure your file matches your instructor's output.
 
-As of Sept. 2020, wc gives the following output:
+As of March. 2026, wc gives the following output:
 
 ```bash
 $ wc bad_reads.txt
 ```
 
 ```output
-  802    1338   24012 bad_reads.txt
+  537    1073   23217 bad_reads.txt
 ```
 
 This will tell us the number of lines, words and characters in the file. If we
@@ -226,7 +226,7 @@ $ wc -l bad_reads.txt
 ```
 
 ```output
-802 bad_reads.txt
+537 bad_reads.txt
 ```
 
 :::::::::::::::::::::::::::::::::::::::  challenge
@@ -305,7 +305,7 @@ $ wc -l bad_reads.txt
 ```
 
 ```output
-802 bad_reads.txt
+537 bad_reads.txt
 ```
 
 ```bash
@@ -324,14 +324,18 @@ search sequence. So our file was overwritten and is now empty.
 We can avoid overwriting our files by using the command `>>`. `>>` is known as the "append redirect" and will
 append new output to the end of a file, rather than overwriting it.
 
+First, run the `grep` command for the (`SRR098026.fastq`) file.
+
 ```bash
 $ grep -B1 -A2 NNNNNNNNNN SRR098026.fastq > bad_reads.txt
 $ wc -l bad_reads.txt
 ```
 
 ```output
-802 bad_reads.txt
+537 bad_reads.txt
 ```
+
+Then, run the `grep` command for the (`SRR097977.fastq`) file, appending the output of this command to (`bad_reads.txt`) 
 
 ```bash
 $ grep -B1 -A2 NNNNNNNNNN SRR097977.fastq >> bad_reads.txt
@@ -339,12 +343,12 @@ $ wc -l bad_reads.txt
 ```
 
 ```output
-802 bad_reads.txt
+537 bad_reads.txt
 ```
 
 The output of our second call to `wc` shows that we have not overwritten our original data.
 
-We can also do this with a single line of code by using a wildcard:
+We can also do this with a single line of code by using a wildcard to match both `fastq` files in our directory:
 
 ```bash
 $ grep -B1 -A2 NNNNNNNNNN *.fastq > bad_reads.txt
@@ -352,7 +356,7 @@ $ wc -l bad_reads.txt
 ```
 
 ```output
-802 bad_reads.txt
+537 bad_reads.txt
 ```
 
 :::::::::::::::::::::::::::::::::::::::::  callout
@@ -423,11 +427,11 @@ $ tail bad_reads.txt
 ```
 
 ```output
+#!!!!!!!!!##########!!!!!!!!!!##!#!
 @SRR098026.133 HWUSI-EAS1599_1:2:1:0:1978 length=35
 ANNNNNNNNNTTCAGCGACTNNNNNNNNNNGTNGN
 +SRR098026.133 HWUSI-EAS1599_1:2:1:0:1978 length=35
 #!!!!!!!!!##########!!!!!!!!!!##!#!
---
 --
 @SRR098026.177 HWUSI-EAS1599_1:2:1:1:2025 length=35
 CNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
@@ -435,7 +439,7 @@ CNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ```
 
-The fifth and six lines in the output display "--" which is the default action for `grep` to separate groups of
+The sixth line in the output displays "--" which is the default action for `grep` to separate groups of
 lines matching the pattern, and indicate groups of lines which did not match the pattern so are not displayed.
 To fix this issue, we can redirect the output of grep to a second instance of `grep` as follows.
 


### PR DESCRIPTION
Updated `grep` section to reflect outputs as of March 2026. 

The data available from https://figshare.com/articles/dataset/Data_Carpentry_Genomics_beta_2_0/7726454?file=14417834 for this lesson does not produce the same number of read matches for each `wc` command. Additionally, the `tail` command with `SRR098026.fastq` does not produce the same output due to the file. The numbers and outputs have been changed to reflect the current data.

Additionally, added short instructions in between the commands writing and appending to files since just the commands and outputs do not make it clear what is happening.

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._


_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
